### PR TITLE
format: use reflect.Value as Stringer to print

### DIFF
--- a/format/debug.go
+++ b/format/debug.go
@@ -185,7 +185,7 @@ func (p *debugPrinter) printv(v reflect.Value) {
 		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
 		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
-		p.printf("%s(%v)", v.Type().Name(), v.Interface())
+		p.printf("%s(%v)", v.Type().Name(), v)
 	default:
 		if !v.IsValid() {
 			p.printf("?")


### PR DESCRIPTION
This CL uses the reflect.Value as a Stringer to print values passed to
ng, instead of using reflect.Value.Interface().
Using reflect.Value.Interface() may try to create a new reflect.Value
from an unexported field, and this will make Interface() panic.

Fixes neugram/ng#17.