### PR TITLE
ng: properly restore terminal state

### DIFF
--- a/ng.go
+++ b/ng.go
@@ -116,6 +116,8 @@ func main() {
 
 	origMode = mode()
 	lineNg = liner.NewLiner()
+	defer lineNg.Close()
+
 	loop()
 }
 


### PR DESCRIPTION
This CL adds the needed code to properly restore the terminal state even
when ng panics for some reason.