### PR TITLE
ng: add new line when exiting

### DIFF
--- a/ng.go
+++ b/ng.go
@@ -46,6 +46,7 @@ func exit(code int) {
 	if lineNg != nil {
 		lineNg.Close()
 	}
+	fmt.Fprintf(os.Stderr, "\n")
 	os.Exit(code)
 }
 


### PR DESCRIPTION
This CL adds a new line when exiting the ng interactive shell.

Previously, hitting ^D would result in:
```
   my-shell> ng
   ng> print("hello")
   hello
   ng> ^Dmy-shell>
```
Now, the host shell prompt is tacked at the very left:
```
   my-shell> ng
   ng> print("hello")
   hello
   ng> ^D
   my-shell>
```
This is more in-line with other interactive REPLs such as python.