### PR TITLE
eval: remove unused code

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -800,10 +800,6 @@ func (p *Program) evalStmt(s stmt.Stmt) []reflect.Value {
 		if !isStruct {
 			panic("eval only supports methodik on struct types")
 		}
-		var methodFuncs []reflect.Type
-		for _, m := range t.Methods {
-			methodFuncs = append(methodFuncs, r.ToRType(m))
-		}
 		var fields []reflect.StructField
 		for i, name := range t.MethodNames {
 			funcType := r.ToRType(t.Methods[i])


### PR DESCRIPTION
Just making a trivial PR from my non-organization fork, to test the theory in https://github.com/neugram/ng/pull/15#issuecomment-341098745. Let's see if Travis picks it up and runs its checks on it.

---

`methodFuncs` was unused.

Found with @dominikh's [`staticcheck`](https://staticcheck.io/docs/staticcheck#overview) tool:

```
eval/eval.go:805:24: this result of append is never used, except maybe in other appends (SA4010)
```