### PR TITLE
all: implement complex

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -933,8 +933,7 @@ func convert(v reflect.Value, t reflect.Type) reflect.Value {
 		switch t {
 		case reflect.TypeOf(UntypedComplex{}):
 			res := UntypedComplex{new(big.Float), new(big.Float)}
-			f, _ := val.Float64()
-			res.Real.SetFloat64(f)
+			res.Real.Set(val.Float)
 			return reflect.ValueOf(res)
 		}
 		ret := reflect.New(t).Elem()

--- a/eval/op.go
+++ b/eval/op.go
@@ -693,14 +693,16 @@ func typeConv(t reflect.Type, v reflect.Value) (res reflect.Value) {
 		}
 		return reflect.ValueOf(float64(v.Int()))
 	case reflect.Complex64:
-		if v.Kind() == reflect.Complex64 {
+		switch v.Kind() {
+		case reflect.Complex64, reflect.Complex128:
 			res = reflect.New(t).Elem()
 			res.SetComplex(v.Complex())
 			return res
 		}
 		return reflect.ValueOf(complex(float32(v.Int()), 0))
 	case reflect.Complex128:
-		if v.Kind() == reflect.Complex128 {
+		switch v.Kind() {
+		case reflect.Complex64, reflect.Complex128:
 			res = reflect.New(t).Elem()
 			res.SetComplex(v.Complex())
 			return res

--- a/eval/testdata/complex.ng
+++ b/eval/testdata/complex.ng
@@ -8,14 +8,84 @@ complex(1.1, 2.2)
 complex(1.1, float32(2))
 complex(1.1, float64(2))
 
-complex(float32(2), float32(3))
+complex(float32(2), float32(3)) + complex64(2)
 
-complex(float64(2), float64(3))
+complex(float64(2), float64(3)) + complex128(0)
 
-// TODO: c := complex128(0) + complex128(complex64(3.5))
-// TODO: real(1 + 2i) == 1.0
-// TODO: imag(1 + 2i) == 2.0
+complex128(0) + complex128(2.2) + complex128(complex64(3.5)+complex64(3))
+complex128(1) + 1
+complex64(1) + 1
 
-complex(real(complex(1, 2)), imag(complex(1, 2)))
+(complex128(0) + complex128(3.3)) + complex(1, 2)
+
+// TODO: c := 2*(complex128(2) + complex(1,2)) + 1
+// TODO: c := complex(1,2) + complex64(2)
+
+real(1 + 2i)
+real(1 + 2i) + 2
+real(1 + 2i) + 2.2
+// TODO: real(1 + 2i) + float32(2.2)
+real(1 + 2i) + float64(2.2)
+
+real(complex64(1)) + 1
+real(complex64(1)) + 1.1
+real(complex64(1)) + float32(1)
+
+imag(1 + 2i)
+imag(1 + 2i) + 2
+imag(1 + 2i) + 2.2
+// TODO: imag(1 + 2i) + float32(2.2)
+imag(1 + 2i) + float64(2.2)
+
+imag(complex64(1)) + 1
+imag(complex64(1)) + 1.1
+imag(complex64(1)) + float32(1)
+
+
+if real(1 + 2i) != 1.0 {
+	panic("ERROR")
+}
+
+if imag(1 + 2i) != 2.0 {
+	panic("ERROR")
+}
+
+c := complex(1, 2)
+cc := 1 + 2i
+if c != cc {
+	panic("ERROR")
+}
+
+if real(c) != 1.0 {
+	panic("ERROR")
+}
+
+if imag(c) != 2.0 {
+	panic("ERROR")
+}
+
+c1 := complex(real(complex(1, 2)), imag(complex(1, 2)))
+if c1 != complex(1, 2) {
+	panic("ERROR")
+}
+
+c2 := complex(2, 3)
+c3 := c1 + c2
+
+if real(c3) != 3 {
+	panic("ERROR")
+}
+
+if imag(c3) != 5 {
+	panic("ERROR")
+}
+
+func add(c1, c2 complex128) complex128 {
+	return c1 + c2
+}
+
+if add(c1, c2) != c3 {
+	panic("ERROR")
+}
 
 print("OK")

--- a/internal/bigcplx/big.go
+++ b/internal/bigcplx/big.go
@@ -1,0 +1,35 @@
+// Copyright 2017 The Neugram Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bigcplx
+
+import "math/big"
+
+type Complex struct {
+	Real *big.Float
+	Imag *big.Float
+}
+
+func New(v complex128) *Complex {
+	return &Complex{
+		Real: big.NewFloat(real(v)),
+		Imag: big.NewFloat(imag(v)),
+	}
+}
+
+func (c *Complex) Set(x *Complex) *Complex {
+	c.Real.Set(x.Real)
+	c.Imag.Set(x.Imag)
+	return c
+}
+
+func (c *Complex) SetComplex128(x complex128) *Complex {
+	c.Real.SetFloat64(real(x))
+	c.Imag.SetFloat64(imag(x))
+	return c
+}
+
+func (c *Complex) String() string {
+	return c.Real.String() + " + " + c.Imag.String() + "i"
+}

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"neugram.io/ng/internal/bigcplx"
 	"neugram.io/ng/token"
 )
 
@@ -187,9 +188,12 @@ exponent:
 			tok = token.Unknown
 		}
 	case token.Imaginary:
+		str = str[:len(str)-1] // drop trailing 'i'
 		f, ok := big.NewFloat(0).SetString(str)
 		if ok {
-			value = f
+			cmplx := bigcplx.New(0)
+			cmplx.Imag = f
+			value = cmplx
 		} else {
 			s.errorf("bad complex literal: %q", str)
 			tok = token.Unknown

--- a/tipe/tipe.go
+++ b/tipe/tipe.go
@@ -313,7 +313,15 @@ func Equal(x, y Type) bool {
 		if !ok {
 			return false
 		}
-		return x == y
+		switch {
+		case x == Float && (y == Float32 || y == Float64):
+			// handle floatXX <- float
+			return true
+		case x == Complex && (y == Complex64 || y == Complex128):
+			return true
+		default:
+			return x == y
+		}
 	case Builtin:
 		y, ok := y.(Builtin)
 		if !ok {


### PR DESCRIPTION
This CL adds correct handling of type decay for
float->float(32|64) and complex->complex(64|128).

It also adds the needed big.Float-like type to handle complexes
of multi-precision (ie: internal/bigcplx.Complex)