### PR TITLE
eval: make interpPanic implement error interface

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -997,6 +997,10 @@ type interpPanic struct {
 	reason error
 }
 
+func (p interpPanic) Error() string {
+	return p.reason.Error()
+}
+
 func (p *Program) prepCall(e *expr.Call) (fn reflect.Value, args []reflect.Value) {
 	fn = p.evalExprOne(e.Func)
 	args = make([]reflect.Value, len(e.Args))


### PR DESCRIPTION
interpPanic is used as an argument to panic, so have it
implement the error interface.

This CL implements just that.