### PR TITLE
Chan comma ok

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1386,7 +1386,11 @@ func (p *Program) evalExpr(e expr.Expr) []reflect.Value {
 		case token.ChanOp:
 			ch := p.evalExprOne(e.Expr)
 			res, ok := ch.Recv()
-			_ = ok // TODO
+			switch et := p.Types.Types[e].(type) {
+			case *tipe.Tuple:
+				t := p.reflector.ToRType(et.Elems[0])
+				return []reflect.Value{convert(res, t), reflect.ValueOf(ok)}
+			}
 			v = res
 		}
 		t := p.reflector.ToRType(p.Types.Types[e])

--- a/eval/testdata/chan2.ng
+++ b/eval/testdata/chan2.ng
@@ -1,0 +1,31 @@
+ch := make(chan int)
+go func() {
+	ch <- 42
+	ch <- 43
+	close(ch)
+}()
+
+v, ok := <-ch
+if !ok {
+	panic("ERROR")
+}
+
+if v != 42 {
+	panic("ERROR")
+}
+
+v += <-ch
+if v != 85 {
+	panic("ERROR")
+}
+
+v, ok = <-ch
+if ok {
+	panic("ERROR")
+}
+if v != 0 {
+	panic("ERROR")
+}
+
+print("OK")
+


### PR DESCRIPTION
This CL implements the comma-ok idiom for a ChanRecv expression:

```go
v1, ok := <-ch
v2 := <-ch
v3 += <-ch
```

Fixes neugram/ng#36.