### PR TITLE
eval,typecheck: implement comma-ok for map

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1230,9 +1230,7 @@ func (p *Program) evalExpr(e expr.Expr) []reflect.Value {
 			if !exists {
 				v = reflect.Zero(container.Type().Elem())
 			}
-			if t, returnExists := p.Types.Type(e).(*tipe.Tuple); returnExists {
-				// TODO: type checker is not generating this tuple yet.
-				fmt.Printf("index t=%v\n", t)
+			if _, returnExists := p.Types.Type(e).(*tipe.Tuple); returnExists {
 				return []reflect.Value{v, reflect.ValueOf(exists)}
 			}
 			return []reflect.Value{v}

--- a/eval/testdata/map2.ng
+++ b/eval/testdata/map2.ng
@@ -1,0 +1,41 @@
+m := make(map[string]int)
+m["one"] = 1
+
+v, ok := m["one"]
+if !ok {
+	panic("ERROR")
+}
+if v != 1 {
+	panic("ERROR")
+}
+
+v, ok = m["not-there"]
+if ok {
+	panic("ERROR")
+}
+if v != 0 {
+	panic("ERROR")
+}
+
+v += m["one"]
+if v != 1 {
+	panic("ERROR")
+}
+
+func f() map[string]int { return map[string]int{ "one": 11 } }
+
+v, ok = f()["one"]
+if !ok {
+	panic("ERROR")
+}
+
+if v != 11 {
+	panic("ERROR")
+}
+
+v += f()["one"]
+if v != 22 {
+	panic("ERROR")
+}
+
+print("OK")

--- a/format/expr.go
+++ b/format/expr.go
@@ -56,6 +56,16 @@ func (p *printer) expr(e expr.Expr) {
 		*/
 	case *expr.Ident:
 		p.buf.WriteString(e.Name)
+	case *expr.Index:
+		p.expr(e.Left)
+		p.buf.WriteString("[")
+		for i, idx := range e.Indicies {
+			if i > 0 {
+				p.buf.WriteString(":")
+			}
+			p.expr(idx)
+		}
+		p.buf.WriteString("]")
 	case *expr.Call:
 		WriteExpr(p.buf, e.Func)
 		p.buf.WriteString("(")


### PR DESCRIPTION
This CL implements the comma-ok idiom for a map-indexing expression:

v1, ok := m["1"]
v2 := m["2"]
v3 += m["3"]

Fixes neugram/ng#35.