### PR TITLE
typecheck: avoid panic on too many return args

### DIFF
--- a/eval/testdata/func_error.ng
+++ b/eval/testdata/func_error.ng
@@ -1,0 +1,1 @@
+func f() { return 1 } // ERROR: too many arguments to return

--- a/typecheck/typecheck.go
+++ b/typecheck/typecheck.go
@@ -421,6 +421,7 @@ func (c *Checker) stmt(s stmt.Stmt, retType *tipe.Tuple) tipe.Type {
 	case *stmt.Return:
 		if retType == nil || len(s.Exprs) > len(retType.Elems) {
 			c.errorf("too many arguments to return")
+			return nil
 		}
 		var partials []partial
 		for i, e := range s.Exprs {


### PR DESCRIPTION
Previously we would try to typecheck each expression
with its corresponding type in the return type tuple.
This panics if we try to return too many expressions.
The appropriate error has already been reported so
simply exit early.