### PR TITLE
Support function calls that don't elide errors

### DIFF
--- a/eval/testdata/error6.ng
+++ b/eval/testdata/error6.ng
@@ -11,7 +11,6 @@ g(f())
 g(f() + f())
 g($$ echo hello $$)
 
-/* TODO
 func both(x string, err error) {
 	if err != nil {
 		panic(err)
@@ -20,8 +19,7 @@ func both(x string, err error) {
 }
 
 both(f())
-*/
 
-if count == 10 {
+if count == 11 {
 	print("OK")
 }

--- a/format/expr.go
+++ b/format/expr.go
@@ -30,14 +30,15 @@ func (p *printer) expr(e expr.Expr) {
 		p.buf.WriteString(e.Op.String())
 		WriteExpr(p.buf, e.Expr)
 
-		/* TODO
-		case *expr.Bad:
-			panic("not implemented")
-		case *expr.Selector:
-			panic("not implemented")
-		case *expr.Slice:
-			panic("not implemented")
-		*/
+	/* TODO
+	case *expr.Bad:
+		panic("not implemented")
+	case *expr.Slice:
+		panic("not implemented")
+	*/
+	case *expr.Selector:
+		p.expr(e.Left)
+		p.buf.WriteString("." + e.Right.Name)
 	case *expr.BasicLiteral:
 		p.buf.WriteString(fmt.Sprintf("%v", e.Value))
 		/* TODO

--- a/format/tipe.go
+++ b/format/tipe.go
@@ -116,6 +116,9 @@ func (p *printer) tipe(t tipe.Type) {
 			p.tipe(elt)
 		}
 		p.buf.WriteString(")")
+	case *tipe.Ellipsis:
+		p.tipe(t.Elem)
+		p.buf.WriteString("...")
 	default:
 		p.buf.WriteString("format: unknown type: ")
 		WriteDebug(p.buf, t)

--- a/tipe/tipe.go
+++ b/tipe/tipe.go
@@ -249,6 +249,11 @@ func IsNumeric(t Type) bool {
 	return false
 }
 
+func IsUntypedNil(t Type) bool {
+	b, _ := Underlying(t).(Basic)
+	return b == UntypedNil
+}
+
 func UsesNum(t Type) bool {
 	t = Unalias(t)
 	switch t := t.(type) {

--- a/typecheck/base.go
+++ b/typecheck/base.go
@@ -36,7 +36,7 @@ var universeObjs = map[string]*Obj{
 		Kind: ObjVar,
 		Type: &tipe.Func{
 			Params: &tipe.Tuple{Elems: []tipe.Type{
-				&tipe.Slice{Elem: &tipe.Interface{}},
+				&tipe.Ellipsis{Elem: &tipe.Interface{}},
 			}},
 			Variadic: true,
 		},
@@ -46,7 +46,7 @@ var universeObjs = map[string]*Obj{
 		Type: &tipe.Func{
 			Params: &tipe.Tuple{Elems: []tipe.Type{
 				tipe.String,
-				&tipe.Slice{Elem: &tipe.Interface{}},
+				&tipe.Ellipsis{Elem: &tipe.Interface{}},
 			}},
 			Variadic: true,
 		},
@@ -56,7 +56,7 @@ var universeObjs = map[string]*Obj{
 		Type: &tipe.Func{
 			Params: &tipe.Tuple{Elems: []tipe.Type{
 				tipe.String,
-				&tipe.Slice{Elem: &tipe.Interface{}},
+				&tipe.Ellipsis{Elem: &tipe.Interface{}},
 			}},
 			Results:  &tipe.Tuple{Elems: []tipe.Type{errorType}},
 			Variadic: true,


### PR DESCRIPTION
Given three functions f, g, and h:

```go
func f() (int, error) { return 1, nil }
func g(int) { }
func h(int, error) { }
```

We previously supported `g(f())` but not `h(f())` because
we greedily elided errors, causing the call of h to fail
because only one parameter was passed in.

Rewrite `(*typecheck.Checker).exprPartialCall` to support
this case by improving how we detect how many parameters
there are.

To do this we take a hint from go/types and introduce
the `unpack` function which abstracts the Go spec's
complexity around how many values an expression like `f()`
actually yields, since it depends on context.

As a nice side effect we end up supporting slightly more
of the Go spec, too.