### PR TITLE
parser,stmt: first stab at parsing switch

### DIFF
--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -628,6 +628,31 @@ func equalFuncLiteral(f0, f1 *expr.FuncLiteral) bool {
 	return true
 }
 
+func equalCases(c1, c2 []stmt.Case) bool {
+	if len(c1) != len(c2) {
+		return false
+	}
+	for i := range c1 {
+		if !equalCase(c1[i], c2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalCase(c1, c2 stmt.Case) bool {
+	if !equalExprs(c1.Conds, c2.Conds) {
+		return false
+	}
+	if c1.Default != c2.Default {
+		return false
+	}
+	if !EqualStmt(c1.Body, c2.Body) {
+		return false
+	}
+	return true
+}
+
 func EqualStmt(x, y stmt.Stmt) bool {
 	if x == nil && y == nil {
 		return true
@@ -834,6 +859,20 @@ func EqualStmt(x, y stmt.Stmt) bool {
 			return false
 		}
 		if !EqualStmt(x.Stmt, y.Stmt) {
+			return false
+		}
+	case *stmt.Switch:
+		y, ok := y.(*stmt.Switch)
+		if !ok {
+			return false
+		}
+		if !EqualStmt(x.Init, y.Init) {
+			return false
+		}
+		if !EqualExpr(x.Cond, y.Cond) {
+			return false
+		}
+		if !equalCases(x.Cases, y.Cases) {
 			return false
 		}
 	default:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -787,6 +787,79 @@ var stmtTests = []stmtTest{
 			Body: &stmt.Block{},
 		},
 	}}},
+	{"switch {}", &stmt.Switch{}},
+	{`switch {
+	case true:
+	case false:
+	default:
+	}`,
+		&stmt.Switch{
+			Cases: []stmt.Case{
+				{
+					Conds: []expr.Expr{
+						&expr.Ident{
+							Name: "true",
+						},
+					},
+					Body: &stmt.Block{},
+				},
+				{
+					Conds: []expr.Expr{
+						&expr.Ident{
+							Name: "false",
+						},
+					},
+					Body: &stmt.Block{},
+				},
+				{
+					Default: true,
+					Body:    &stmt.Block{},
+				},
+			},
+		},
+	},
+	{`switch i := fct(); i {
+	case 42, 66:
+	default:
+	}`,
+		&stmt.Switch{
+			Init: &stmt.Assign{
+				Decl: true,
+				Left: []expr.Expr{
+					&expr.Ident{
+						Name: "i",
+					},
+				},
+				Right: []expr.Expr{
+					&expr.Call{
+						Func: &expr.Ident{
+							Name: "fct",
+						},
+					},
+				},
+			},
+			Cond: &expr.Ident{
+				Name: "i",
+			},
+			Cases: []stmt.Case{
+				{
+					Conds: []expr.Expr{
+						&expr.BasicLiteral{
+							Value: big.NewInt(42),
+						},
+						&expr.BasicLiteral{
+							Value: big.NewInt(66),
+						},
+					},
+					Body: &stmt.Block{},
+				},
+				{
+					Default: true,
+					Body:    &stmt.Block{},
+				},
+			},
+		},
+	},
 }
 
 func TestParseStmt(t *testing.T) {

--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -67,6 +67,18 @@ type For struct {
 	Body Stmt // always *BlockStmt
 }
 
+type Switch struct {
+	Init  Stmt
+	Cond  expr.Expr
+	Cases []Case
+}
+
+type Case struct {
+	Conds   []expr.Expr
+	Default bool
+	Body    Stmt // always *BlockStmt
+}
+
 type Go struct {
 	Call *expr.Call
 }
@@ -115,6 +127,8 @@ func (s Assign) stmt()       {}
 func (s Block) stmt()        {}
 func (s If) stmt()           {}
 func (s For) stmt()          {}
+func (s Switch) stmt()       {}
+func (s Case) stmt()         {}
 func (s Go) stmt()           {}
 func (s Range) stmt()        {}
 func (s Return) stmt()       {}


### PR DESCRIPTION
This CL implements the basics of parsing switch statements.
It doesn't handle the body of cases.