### PR TITLE
parser,stmt,token: implement parsing of select

### DIFF
--- a/format/stmt.go
+++ b/format/stmt.go
@@ -25,6 +25,48 @@ func (p *printer) stmt(s stmt.Stmt) {
 			}
 			p.expr(e)
 		}
+	case *stmt.Assign:
+		for i, e := range s.Left {
+			if i > 0 {
+				p.buf.WriteString(", ")
+			}
+			p.expr(e)
+		}
+		p.buf.WriteString(" ")
+		if s.Decl {
+			p.buf.WriteString(":")
+		}
+		p.buf.WriteString("= ")
+		for i, e := range s.Right {
+			if i > 0 {
+				p.buf.WriteString(", ")
+			}
+			p.expr(e)
+		}
+	case *stmt.Send:
+		p.expr(s.Chan)
+		p.buf.WriteString("<-")
+		p.expr(s.Value)
+	case *stmt.Select:
+		p.buf.WriteString("select {")
+		for _, c := range s.Cases {
+			switch c.Default {
+			case true:
+				p.buf.WriteString("default:")
+			default:
+				p.buf.WriteString("case ")
+				p.stmt(c.Stmt)
+				p.buf.WriteString(":")
+			}
+			p.stmt(c.Body)
+		}
+		p.buf.WriteString("}")
+	case *stmt.Block:
+		p.buf.WriteString("{")
+		for _, s := range s.Stmts {
+			p.stmt(s)
+		}
+		p.buf.WriteString("}")
 	default:
 		p.printf("format: unknown stmt %T: ", s)
 		WriteDebug(p.buf, s)

--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -653,19 +653,19 @@ func equalCase(c1, c2 stmt.Case) bool {
 	return true
 }
 
-func equalCommCases(c1, c2 []stmt.CommCase) bool {
+func equalSelectCases(c1, c2 []stmt.SelectCase) bool {
 	if len(c1) != len(c2) {
 		return false
 	}
 	for i := range c1 {
-		if !equalCommCase(c1[i], c2[i]) {
+		if !equalSelectCase(c1[i], c2[i]) {
 			return false
 		}
 	}
 	return true
 }
 
-func equalCommCase(c1, c2 stmt.CommCase) bool {
+func equalSelectCase(c1, c2 stmt.SelectCase) bool {
 	if c1.Default != c2.Default {
 		return false
 	}
@@ -905,7 +905,7 @@ func EqualStmt(x, y stmt.Stmt) bool {
 		if !ok {
 			return false
 		}
-		if !equalCommCases(x.Cases, y.Cases) {
+		if !equalSelectCases(x.Cases, y.Cases) {
 			return false
 		}
 	default:

--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -653,6 +653,31 @@ func equalCase(c1, c2 stmt.Case) bool {
 	return true
 }
 
+func equalCommCases(c1, c2 []stmt.CommCase) bool {
+	if len(c1) != len(c2) {
+		return false
+	}
+	for i := range c1 {
+		if !equalCommCase(c1[i], c2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalCommCase(c1, c2 stmt.CommCase) bool {
+	if c1.Default != c2.Default {
+		return false
+	}
+	if !EqualStmt(c1.Stmt, c2.Stmt) {
+		return false
+	}
+	if !EqualStmt(c1.Body, c2.Body) {
+		return false
+	}
+	return true
+}
+
 func EqualStmt(x, y stmt.Stmt) bool {
 	if x == nil && y == nil {
 		return true
@@ -873,6 +898,14 @@ func EqualStmt(x, y stmt.Stmt) bool {
 			return false
 		}
 		if !equalCases(x.Cases, y.Cases) {
+			return false
+		}
+	case *stmt.Select:
+		y, ok := y.(*stmt.Select)
+		if !ok {
+			return false
+		}
+		if !equalCommCases(x.Cases, y.Cases) {
 			return false
 		}
 	default:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -998,7 +998,7 @@ func (p *Parser) parseSelect() stmt.Stmt {
 
 	s := new(stmt.Select)
 	for p.s.Token != token.RightBrace {
-		var c stmt.CommCase
+		var c stmt.SelectCase
 		switch p.s.Token {
 		case token.Case:
 			p.expect(token.Case)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -902,6 +902,93 @@ var stmtTests = []stmtTest{
 			},
 		},
 	},
+	{"select {}", &stmt.Select{}},
+	{`select {
+	case v := <-ch1:
+		print(v)
+	case v, ok := <-ch2:
+		print(v, ok)
+	case ch3 <- vv:
+		print(ch3)
+	default:
+		print(42)
+	}`,
+		&stmt.Select{
+			Cases: []stmt.CommCase{
+				{
+					Stmt: &stmt.Assign{
+						Decl: true,
+						Left: []expr.Expr{
+							&expr.Ident{
+								Name: "v",
+							},
+						},
+						Right: []expr.Expr{
+							&expr.Unary{
+								Op: token.ChanOp,
+								Expr: &expr.Ident{
+									Name: "ch1",
+								},
+							},
+						},
+					},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "v"}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Stmt: &stmt.Assign{
+						Decl:  true,
+						Left:  []expr.Expr{&expr.Ident{Name: "v"}, &expr.Ident{Name: "ok"}},
+						Right: []expr.Expr{&expr.Unary{Op: token.ChanOp, Expr: &expr.Ident{Name: "ch2"}}},
+					},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "v"}, &expr.Ident{Name: "ok"}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Stmt: &stmt.Send{Chan: &expr.Ident{Name: "ch3"}, Value: &expr.Ident{Name: "vv"}},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "ch3"}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Default: true,
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(42)}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParseStmt(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -914,7 +914,7 @@ var stmtTests = []stmtTest{
 		print(42)
 	}`,
 		&stmt.Select{
-			Cases: []stmt.CommCase{
+			Cases: []stmt.SelectCase{
 				{
 					Stmt: &stmt.Assign{
 						Decl: true,

--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -116,10 +116,10 @@ type Labeled struct {
 }
 
 type Select struct {
-	Cases []CommCase
+	Cases []SelectCase
 }
 
-type CommCase struct {
+type SelectCase struct {
 	Default bool
 	Stmt    Stmt // a recv- or send-stmt
 	Body    *Block

--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -115,6 +115,16 @@ type Labeled struct {
 	Stmt  Stmt
 }
 
+type Select struct {
+	Cases []CommCase
+}
+
+type CommCase struct {
+	Default bool
+	Stmt    Stmt // a recv- or send-stmt
+	Body    *Block
+}
+
 type Bad struct {
 }
 
@@ -136,4 +146,5 @@ func (s Simple) stmt()       {}
 func (s Send) stmt()         {}
 func (s Branch) stmt()       {}
 func (s Labeled) stmt()      {}
+func (s Select) stmt()       {}
 func (s Bad) stmt()          {}

--- a/token/token.go
+++ b/token/token.go
@@ -84,6 +84,7 @@ const (
 	Func
 	Return
 
+	Select
 	Switch
 	Case
 	Default
@@ -172,6 +173,7 @@ var Keywords = map[string]Token{
 	"import":      Import,
 	"func":        Func,
 	"return":      Return,
+	"select":      Select,
 	"switch":      Switch,
 	"case":        Case,
 	"default":     Default,


### PR DESCRIPTION
This CL adds support for parsing select statements.
Parsing select statements doesn't yet support bodies for the select
communication cases.

Updates neugram/ng#41.