### PR TITLE
parser: support for parsing bodies in switch-cases

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1097,19 +1097,15 @@ func (p *Parser) parseSwitch() stmt.Stmt {
 			p.expect(token.Case)
 			p.next()
 			c.Conds = p.parseExprs()
-			p.expect(token.Colon)
 		case token.Default:
 			p.expect(token.Default)
 			p.next()
-			p.expect(token.Colon)
 			c.Default = true
 		}
-		// FIXME(sbinet)
-		//p.next()
-		//c.Body = &stmt.Block{Stmts: p.parseStmts()}
-		c.Body = &stmt.Block{}
-		s.Cases = append(s.Cases, c)
+		p.expect(token.Colon)
 		p.next()
+		c.Body = &stmt.Block{Stmts: p.parseStmts()}
+		s.Cases = append(s.Cases, c)
 	}
 	p.expect(token.RightBrace)
 	p.next()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -790,8 +790,11 @@ var stmtTests = []stmtTest{
 	{"switch {}", &stmt.Switch{}},
 	{`switch {
 	case true:
+		print(true)
 	case false:
+		print(false)
 	default:
+		print(42)
 	}`,
 		&stmt.Switch{
 			Cases: []stmt.Case{
@@ -801,26 +804,51 @@ var stmtTests = []stmtTest{
 							Name: "true",
 						},
 					},
-					Body: &stmt.Block{},
-				},
-				{
-					Conds: []expr.Expr{
-						&expr.Ident{
-							Name: "false",
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "true"}},
+								},
+							},
 						},
 					},
-					Body: &stmt.Block{},
+				},
+				{
+					Conds: []expr.Expr{&expr.Ident{Name: "false"}},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "false"}},
+								},
+							},
+						},
+					},
 				},
 				{
 					Default: true,
-					Body:    &stmt.Block{},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(42)}},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 	},
 	{`switch i := fct(); i {
 	case 42, 66:
+		print(i)
 	default:
+		print(ok)
 	}`,
 		&stmt.Switch{
 			Init: &stmt.Assign{
@@ -844,18 +872,32 @@ var stmtTests = []stmtTest{
 			Cases: []stmt.Case{
 				{
 					Conds: []expr.Expr{
-						&expr.BasicLiteral{
-							Value: big.NewInt(42),
-						},
-						&expr.BasicLiteral{
-							Value: big.NewInt(66),
+						&expr.BasicLiteral{Value: big.NewInt(42)},
+						&expr.BasicLiteral{Value: big.NewInt(66)},
+					},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "i"}},
+								},
+							},
 						},
 					},
-					Body: &stmt.Block{},
 				},
 				{
 					Default: true,
-					Body:    &stmt.Block{},
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Simple{
+								Expr: &expr.Call{
+									Func: &expr.Ident{Name: "print"},
+									Args: []expr.Expr{&expr.Ident{Name: "ok"}},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This CL adds the support for parsing the bodies of cases in switch
statements.