### PR TITLE
 expr,format,parser,stmt: introduce TypeSwitch

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -47,7 +47,7 @@ type Index struct {
 
 type TypeAssert struct {
 	Left Expr
-	Type tipe.Type
+	Type tipe.Type // asserted type; nil means type switch X.(type)
 }
 
 type BasicLiteral struct {

--- a/format/expr.go
+++ b/format/expr.go
@@ -70,7 +70,11 @@ func (p *printer) expr(e expr.Expr) {
 	case *expr.TypeAssert:
 		p.expr(e.Left)
 		p.buf.WriteString(".(")
-		WriteType(p.buf, e.Type)
+		if e.Type == nil {
+			p.buf.WriteString("type")
+		} else {
+			WriteType(p.buf, e.Type)
+		}
 		p.buf.WriteString(")")
 	case *expr.Call:
 		WriteExpr(p.buf, e.Func)

--- a/format/stmt.go
+++ b/format/stmt.go
@@ -47,8 +47,43 @@ func (p *printer) stmt(s stmt.Stmt) {
 		p.expr(s.Chan)
 		p.buf.WriteString("<-")
 		p.expr(s.Value)
+	case *stmt.Switch:
+		p.buf.WriteString("switch ")
+		if s.Init != nil {
+			p.stmt(s.Init)
+			if s.Cond != nil {
+				p.buf.WriteString("; ")
+			}
+		}
+		if s.Cond != nil {
+			p.expr(s.Cond)
+		}
+		p.buf.WriteString("{")
+		if len(s.Cases) > 0 {
+			p.buf.WriteString("\n")
+		}
+		for _, c := range s.Cases {
+			switch c.Default {
+			case true:
+				p.buf.WriteString("default:")
+			default:
+				p.buf.WriteString("case ")
+				for i, e := range c.Conds {
+					if i > 0 {
+						p.buf.WriteString(", ")
+					}
+					p.expr(e)
+				}
+				p.buf.WriteString(":\n")
+			}
+			p.stmt(c.Body)
+		}
+		p.buf.WriteString("}")
 	case *stmt.Select:
 		p.buf.WriteString("select {")
+		if len(s.Cases) > 0 {
+			p.buf.WriteString("\n")
+		}
 		for _, c := range s.Cases {
 			switch c.Default {
 			case true:

--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -453,6 +453,18 @@ func equalTuple(x, y *tipe.Tuple) bool {
 	return true
 }
 
+func equalTypes(t0, t1 []tipe.Type) bool {
+	if len(t0) != len(t1) {
+		return false
+	}
+	for i := range t0 {
+		if !equalType(t0[i], t1[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func equalType(t0, t1 tipe.Type) bool {
 	if t0 == nil && t1 == nil {
 		return true
@@ -601,6 +613,17 @@ func equalType(t0, t1 tipe.Type) bool {
 		if t0.Name != t1.Name {
 			return false
 		}
+	case *tipe.Pointer:
+		t1, ok := t1.(*tipe.Pointer)
+		if !ok {
+			return false
+		}
+		if t0 == nil || t1 == nil {
+			return t0 == nil && t1 == nil
+		}
+		if !equalType(t0.Elem, t1.Elem) {
+			return false
+		}
 	default:
 		panic(fmt.Sprintf("unknown type: %T", t0))
 	}
@@ -642,6 +665,31 @@ func equalSwitchCases(c1, c2 []stmt.SwitchCase) bool {
 
 func equalSwitchCase(c1, c2 stmt.SwitchCase) bool {
 	if !equalExprs(c1.Conds, c2.Conds) {
+		return false
+	}
+	if c1.Default != c2.Default {
+		return false
+	}
+	if !EqualStmt(c1.Body, c2.Body) {
+		return false
+	}
+	return true
+}
+
+func equalTypeSwitchCases(c1, c2 []stmt.TypeSwitchCase) bool {
+	if len(c1) != len(c2) {
+		return false
+	}
+	for i := range c1 {
+		if !equalTypeSwitchCase(c1[i], c2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalTypeSwitchCase(c1, c2 stmt.TypeSwitchCase) bool {
+	if !equalTypes(c1.Types, c2.Types) {
 		return false
 	}
 	if c1.Default != c2.Default {
@@ -898,6 +946,20 @@ func EqualStmt(x, y stmt.Stmt) bool {
 			return false
 		}
 		if !equalSwitchCases(x.Cases, y.Cases) {
+			return false
+		}
+	case *stmt.TypeSwitch:
+		y, ok := y.(*stmt.TypeSwitch)
+		if !ok {
+			return false
+		}
+		if !EqualStmt(x.Init, y.Init) {
+			return false
+		}
+		if !EqualStmt(x.Assign, y.Assign) {
+			return false
+		}
+		if !equalTypeSwitchCases(x.Cases, y.Cases) {
 			return false
 		}
 	case *stmt.Select:

--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -79,6 +79,18 @@ type SwitchCase struct {
 	Body    *Block
 }
 
+type TypeSwitch struct {
+	Init   Stmt // initialization statement; or nil
+	Assign Stmt // x := y.(type) or y.(type)
+	Cases  []TypeSwitchCase
+}
+
+type TypeSwitchCase struct {
+	Default bool
+	Types   []tipe.Type
+	Body    *Block
+}
+
 type Go struct {
 	Call *expr.Call
 }
@@ -139,6 +151,7 @@ func (s If) stmt()           {}
 func (s For) stmt()          {}
 func (s Switch) stmt()       {}
 func (s SwitchCase) stmt()   {}
+func (s TypeSwitch) stmt()   {}
 func (s Go) stmt()           {}
 func (s Range) stmt()        {}
 func (s Return) stmt()       {}


### PR DESCRIPTION
This CL only implements the parsing part of a type-switch.

Updates neugram/ng#85.