### PR TITLE
Switch fallthrough error

### DIFF
--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -201,6 +201,9 @@ func TestPrograms(t *testing.T) {
 				if match == nil {
 					t.Fatal("test has _error suffix but no ERROR directive")
 				}
+				if err == nil {
+					t.Fatal("test has _error suffix but no error was detected")
+				}
 				wantStr := match[1]
 				if !strings.Contains(err.Error(), wantStr) {
 					t.Fatalf("want %q, got: %v", wantStr, err.Error())

--- a/eval/testdata/switch12_error.ng
+++ b/eval/testdata/switch12_error.ng
@@ -1,0 +1,7 @@
+i := 42
+switch i {
+case 42:
+	fallthrough // ERROR: cannot fallthrough final case in switch
+}
+
+print("OK")

--- a/eval/testdata/switch13_error.ng
+++ b/eval/testdata/switch13_error.ng
@@ -1,0 +1,8 @@
+i := 42
+switch i {
+case 42:
+	fallthrough // ERROR: fallthrough statement out of place
+	i++
+}
+
+print("OK")

--- a/eval/testdata/typeswitch9_error.ng
+++ b/eval/testdata/typeswitch9_error.ng
@@ -1,0 +1,8 @@
+x := interface{}(42)
+switch x.(type) {
+case int:
+	fallthrough // ERROR: cannot fallthrough in type switch
+default:
+}
+
+print("OK")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1200,6 +1200,9 @@ func (p *Parser) parseExprSwitch(s1, s2 stmt.Stmt) stmt.Stmt {
 			p.expect(token.Default)
 			p.next()
 			c.Default = true
+		default:
+			p.errorf("syntax error: got token %q, want %q or %q", p.s.Token, token.Case, token.Default)
+			return nil
 		}
 		p.expect(token.Colon)
 		p.next()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1244,6 +1244,16 @@ func (p *Parser) parseTypeSwitch(s1, s2 stmt.Stmt) stmt.Stmt {
 		p.expect(token.Colon)
 		p.next()
 		c.Body = &stmt.Block{Stmts: p.parseStmts()}
+		for _, e := range c.Body.Stmts {
+			// TODO: detect fallthrough statements in non-top-level statements
+			switch e := e.(type) {
+			case *stmt.Branch:
+				if e.Type == token.Fallthrough {
+					p.error("cannot fallthrough in type switch")
+				}
+			}
+		}
+
 		s.Cases = append(s.Cases, c)
 	}
 

--- a/typecheck/typecheck.go
+++ b/typecheck/typecheck.go
@@ -629,7 +629,6 @@ func (c *Checker) stmt(s stmt.Stmt, retType *tipe.Tuple) tipe.Type {
 					)
 				}
 			}
-			// TODO: do not allow 'fallthrough' in case body
 			c.stmt(cse.Body, retType)
 		}
 		return nil


### PR DESCRIPTION
detect a few invalid `switch` statements.
we'll fail to detect all of them, especially those that involve nested `fallthrough` until something along the lines of neugram/ng#93 is implemented.

_e.g:_
```go
 switch i {
 case 42:
   if true {
      fallthrough // should fail with: fallthrough statement out of place
   }
 default:
 }
```