### PR TITLE
parser,syntax/stmt,syntax/token: implement var parsing

### DIFF
--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -644,6 +644,33 @@ func EqualStmt(x, y stmt.Stmt) bool {
 		if !EqualExpr(x.Value, y.Value) {
 			return false
 		}
+	case *stmt.Var:
+		y, ok := y.(*stmt.Var)
+		if !ok {
+			return false
+		}
+		if x.Name != y.Name {
+			return false
+		}
+		if !tipe.EqualUnresolved(x.Type, y.Type) {
+			return false
+		}
+		if !EqualExpr(x.Value, y.Value) {
+			return false
+		}
+	case *stmt.VarSet:
+		y, ok := y.(*stmt.VarSet)
+		if !ok {
+			return false
+		}
+		if len(x.Vars) != len(y.Vars) {
+			return false
+		}
+		for i := range x.Vars {
+			if !EqualStmt(x.Vars[i], y.Vars[i]) {
+				return false
+			}
+		}
 	case *stmt.Assign:
 		y, ok := y.(*stmt.Assign)
 		if !ok {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1196,9 +1196,9 @@ func (p *Parser) parseVar() *stmt.Var {
 		s.Type = p.parseType()
 	}
 	if p.s.Token == token.Assign {
-		p.expect(token.Assign)
 		p.next()
 		s.Value = p.parseExpr()
+		p.expectSemi()
 	}
 	return s
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1180,6 +1180,43 @@ var stmtTests = []stmtTest{
 	{"return 1", &stmt.Return{Exprs: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(1)}}}},
 	{"{ return }", &stmt.Block{Stmts: []stmt.Stmt{&stmt.Return{}}}},
 	{"{ return 1 }", &stmt.Block{Stmts: []stmt.Stmt{&stmt.Return{Exprs: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(1)}}}}}},
+	{"var i = 10", &stmt.Var{
+		Name:  "i",
+		Value: &expr.BasicLiteral{Value: big.NewInt(10)},
+	}},
+	{"var i int", &stmt.Var{
+		Name: "i",
+		Type: &tipe.Unresolved{Name: "int"},
+	}},
+	{"var i int = 11", &stmt.Var{
+		Name:  "i",
+		Value: &expr.BasicLiteral{Value: big.NewInt(11)},
+		Type:  &tipe.Unresolved{Name: "int"},
+	}},
+	{
+		`var (
+			i int = 11
+			j = 22
+			k float64
+		)
+		`, &stmt.VarSet{
+			Vars: []*stmt.Var{
+				{
+					Name:  "i",
+					Value: &expr.BasicLiteral{Value: big.NewInt(11)},
+					Type:  &tipe.Unresolved{Name: "int"},
+				},
+				{
+					Name:  "j",
+					Value: &expr.BasicLiteral{Value: big.NewInt(22)},
+				},
+				{
+					Name: "k",
+					Type: &tipe.Unresolved{Name: "float64"},
+				},
+			},
+		},
+	},
 }
 
 func TestParseStmt(t *testing.T) {

--- a/syntax/stmt/stmt.go
+++ b/syntax/stmt/stmt.go
@@ -50,6 +50,18 @@ type Const struct {
 	Value    expr.Expr
 }
 
+type VarSet struct {
+	Position src.Pos
+	Vars     []*Var
+}
+
+type Var struct {
+	Position src.Pos
+	Name     string
+	Type     tipe.Type
+	Value    expr.Expr
+}
+
 type Assign struct {
 	Position src.Pos
 	Decl     bool
@@ -171,6 +183,8 @@ func (s *ImportSet) stmt()      {}
 func (s *TypeDecl) stmt()       {}
 func (s *MethodikDecl) stmt()   {}
 func (s *Const) stmt()          {}
+func (s *Var) stmt()            {}
+func (s *VarSet) stmt()         {}
 func (s *Assign) stmt()         {}
 func (s *Block) stmt()          {}
 func (s *If) stmt()             {}
@@ -194,6 +208,8 @@ func (s *ImportSet) Pos() src.Pos     { return s.Position }
 func (s *TypeDecl) Pos() src.Pos      { return s.Position }
 func (s *MethodikDecl) Pos() src.Pos  { return s.Position }
 func (s *Const) Pos() src.Pos         { return s.Position }
+func (s *Var) Pos() src.Pos           { return s.Position }
+func (s *VarSet) Pos() src.Pos        { return s.Position }
 func (s *Assign) Pos() src.Pos        { return s.Position }
 func (s *Block) Pos() src.Pos         { return s.Position }
 func (s *If) Pos() src.Pos            { return s.Position }

--- a/syntax/token/token.go
+++ b/syntax/token/token.go
@@ -91,6 +91,7 @@ const (
 	Fallthrough
 
 	Const
+	Var
 
 	If
 	Else
@@ -179,6 +180,7 @@ var Keywords = map[string]Token{
 	"default":     Default,
 	"fallthrough": Fallthrough,
 	"const":       Const,
+	"var":         Var,
 	"if":          If,
 	"else":        Else,
 	"for":         For,


### PR DESCRIPTION
This CL implements the parsing of statments such as:
```go
 var i int
 var j int = 42
 var k = 42

 var (
    ii int
    jj int = 42
    kk     = 42
 )
```
Updates neugram/ng#106.