### PR TITLE
eval,parser,typecheck: properly handle return statement with no value

### DIFF
--- a/eval/testdata/func5.ng
+++ b/eval/testdata/func5.ng
@@ -1,0 +1,13 @@
+ok := false
+func f(x int) {
+	ok = true
+	return
+}
+
+f(42)
+
+if !ok {
+	panic("ERROR")
+}
+
+print("OK")

--- a/eval/testdata/func6_error.ng
+++ b/eval/testdata/func6_error.ng
@@ -1,0 +1,1 @@
+func f() { return 1 } // ERROR: too many arguments to return

--- a/eval/testdata/func7_error.ng
+++ b/eval/testdata/func7_error.ng
@@ -1,0 +1,1 @@
+func f() (int, int) { return 1, 2, 3 } // ERROR: too many arguments to return

--- a/eval/testdata/func8_error.ng
+++ b/eval/testdata/func8_error.ng
@@ -1,0 +1,3 @@
+func f() int {
+	return // ERROR: not enough arguments to return
+}

--- a/eval/testdata/func9_error.ng
+++ b/eval/testdata/func9_error.ng
@@ -1,0 +1,1 @@
+func f() int { return } // ERROR: not enough arguments to return

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1025,7 +1025,10 @@ func (p *Parser) parseStmt() stmt.Stmt {
 	case token.Return:
 		pos := p.pos()
 		p.next()
-		s := &stmt.Return{Position: pos, Exprs: p.parseExprs()}
+		s := &stmt.Return{Position: pos}
+		if p.s.Token != token.Semicolon && p.s.Token != token.RightBrace {
+			s.Exprs = p.parseExprs()
+		}
 		p.expectSemi()
 		return s
 	case token.LeftBrace:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1132,6 +1132,54 @@ var stmtTests = []stmtTest{
 			},
 		},
 	},
+	{
+		`
+		select {
+		default:
+		return
+		}
+		`, &stmt.Select{
+			Cases: []stmt.SelectCase{
+				{
+					Default: true,
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Return{},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		`
+		select {
+		default:
+		return 1
+		}
+		`, &stmt.Select{
+			Cases: []stmt.SelectCase{
+				{
+					Default: true,
+					Body: &stmt.Block{
+						Stmts: []stmt.Stmt{
+							&stmt.Return{
+								Exprs: []expr.Expr{
+									&expr.BasicLiteral{
+										Value: big.NewInt(1),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{"return", &stmt.Return{}},
+	{"return 1", &stmt.Return{Exprs: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(1)}}}},
+	{"{ return }", &stmt.Block{Stmts: []stmt.Stmt{&stmt.Return{}}}},
+	{"{ return 1 }", &stmt.Block{Stmts: []stmt.Stmt{&stmt.Return{Exprs: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(1)}}}}}},
 }
 
 func TestParseStmt(t *testing.T) {

--- a/typecheck/typecheck.go
+++ b/typecheck/typecheck.go
@@ -447,8 +447,18 @@ func (c *Checker) stmt(s stmt.Stmt, retType *tipe.Tuple) tipe.Type {
 		return nil
 
 	case *stmt.Return:
-		if retType == nil || len(s.Exprs) > len(retType.Elems) {
+		if retType == nil {
+			if len(s.Exprs) != 0 {
+				c.errorfmt("too many arguments to return")
+			}
+			return nil
+		}
+		switch {
+		case len(s.Exprs) > len(retType.Elems):
 			c.errorfmt("too many arguments to return")
+			return nil
+		case len(s.Exprs) < len(retType.Elems):
+			c.errorfmt("not enough arguments to return")
 			return nil
 		}
 		var partials []partial


### PR DESCRIPTION
Previously, ng wouldn't parse nor typecheck functions like so:
```go
  func foo() { return }
```
This CL fixes this shortcoming.

Fixes neugram/ng#113.