### PR TITLE
eval/gowrap/genwrap: generate wrapper for arrays

### DIFF
--- a/eval/gowrap/genwrap/genwrap.go
+++ b/eval/gowrap/genwrap/genwrap.go
@@ -124,7 +124,7 @@ func nilexpr(t types.Type) string {
 		default:
 			return "(0)"
 		}
-	case *types.Struct:
+	case *types.Array, *types.Struct:
 		return "{}"
 	case *types.Interface, *types.Map, *types.Pointer, *types.Slice, *types.Signature:
 		return "(nil)"


### PR DESCRIPTION
Fixes neugram/ng#115.