### PR TITLE
jupyter,ngcore: implement display data in execute_request

### DIFF
--- a/jupyter/display.go
+++ b/jupyter/display.go
@@ -1,0 +1,52 @@
+// Copyright 2017 The Neugram Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package jupyter
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"net/http"
+	"reflect"
+
+	"neugram.io/ng/ngcore"
+)
+
+// genDisplayData generates a displayData message from values returned by the kernel.
+func genDisplayData(s *ngcore.Session, vals []reflect.Value) (displayData, error) {
+	dd := displayData{
+		Data:      make(map[string]interface{}),
+		Meta:      make(map[string]interface{}),
+		Transient: make(map[string]interface{}),
+	}
+
+	switch len(vals) {
+	case 0:
+		return dd, nil
+	case 1:
+		// TODO: figure out what to do when there are multiple data items to display.
+		// what does the reference kernel (IPython) do?
+		// does it do e.g.:
+		//  data["image/png"] = []string{image(0), image(1), ...}
+		switch v := vals[0].Interface().(type) {
+		case image.Image:
+			buf := new(bytes.Buffer)
+			err := png.Encode(buf, v)
+			if err != nil {
+				return dd, err
+			}
+			dd.Data["image/png"] = buf.Bytes()
+		case []byte:
+			mime := http.DetectContentType(v)
+			dd.Data[mime] = v
+		}
+	}
+
+	txt := new(bytes.Buffer)
+	s.Display(txt, vals)
+	dd.Data["text/plain"] = txt.String()
+
+	return dd, nil
+}

--- a/jupyter/jupyter.go
+++ b/jupyter/jupyter.go
@@ -436,22 +436,13 @@ func (s *server) execute(c *conn, req *message) error {
 		return err
 	}
 
-	nvals := 0
-	for i := range vals {
-		if len(vals[i]) > 0 {
-			nvals++
-		}
-	}
-	if nvals == 0 {
+	if len(vals) == 0 {
 		return nil
 	}
 
-	var dd displayData
-	for _, tuple := range vals {
-		dd, err = genDisplayData(session, tuple)
-		if err != nil {
-			return err
-		}
+	dd, err := genDisplayData(session, vals)
+	if err != nil {
+		return err
 	}
 
 	result := &executeResult{

--- a/ngcore/ngcore.go
+++ b/ngcore/ngcore.go
@@ -105,7 +105,9 @@ func (n *Neugram) GetOrNewSession(ctx context.Context, name string) *Session {
 	return s
 }
 
-func (s *Session) Exec(src []byte) ([][]reflect.Value, error) {
+// Exec returns the evaluation of the content of src and an error, if any.
+// If src contains multiple statements, Exec returns the value of the last one.
+func (s *Session) Exec(src []byte) ([]reflect.Value, error) {
 	var err error
 	stdout := s.Stdout
 	if stdout == nil {
@@ -132,7 +134,7 @@ func (s *Session) Exec(src []byte) ([][]reflect.Value, error) {
 		}
 		return nil, Error{Phase: "parser", List: errs}
 	}
-	out := make([][]reflect.Value, 0, len(res.Stmts))
+	var out []reflect.Value
 	for _, stmt := range res.Stmts {
 		v, err := s.Program.Eval(stmt, nil)
 		if err != nil {
@@ -147,7 +149,7 @@ func (s *Session) Exec(src []byte) ([][]reflect.Value, error) {
 			}
 			return nil, Error{Phase: "eval", List: []error{err}}
 		}
-		out = append(out, v)
+		out = v
 	}
 	for _, cmd := range res.Cmds {
 		j := &shell.Job{


### PR DESCRIPTION
This CL implements displaying data (such as images, PDF, ...) as part of
an execute_request, as part of the execute_result payload.

Updates neugram/ng#128.