### PR TITLE
parser,syntax,syntax/stmt: parse const and const-set

### DIFF
--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -635,14 +635,32 @@ func EqualStmt(x, y stmt.Stmt) bool {
 		if !ok {
 			return false
 		}
-		if x.Name != y.Name {
+		if len(x.NameList) != len(y.NameList) {
 			return false
+		}
+		for i := range x.NameList {
+			if x.NameList[i] != y.NameList[i] {
+				return false
+			}
 		}
 		if !tipe.EqualUnresolved(x.Type, y.Type) {
 			return false
 		}
-		if !EqualExpr(x.Value, y.Value) {
+		if !equalExprs(x.Values, y.Values) {
 			return false
+		}
+	case *stmt.ConstSet:
+		y, ok := y.(*stmt.ConstSet)
+		if !ok {
+			return false
+		}
+		if len(x.Consts) != len(y.Consts) {
+			return false
+		}
+		for i := range x.Consts {
+			if !EqualStmt(x.Consts[i], y.Consts[i]) {
+				return false
+			}
 		}
 	case *stmt.Var:
 		y, ok := y.(*stmt.Var)

--- a/syntax/stmt/stmt.go
+++ b/syntax/stmt/stmt.go
@@ -45,9 +45,14 @@ type MethodikDecl struct {
 
 type Const struct {
 	Position src.Pos
-	Name     string
+	NameList []string
 	Type     tipe.Type
-	Value    expr.Expr
+	Values   []expr.Expr
+}
+
+type ConstSet struct {
+	Position src.Pos
+	Consts   []*Const
 }
 
 type VarSet struct {
@@ -183,6 +188,7 @@ func (s *ImportSet) stmt()      {}
 func (s *TypeDecl) stmt()       {}
 func (s *MethodikDecl) stmt()   {}
 func (s *Const) stmt()          {}
+func (s *ConstSet) stmt()       {}
 func (s *Var) stmt()            {}
 func (s *VarSet) stmt()         {}
 func (s *Assign) stmt()         {}
@@ -208,6 +214,7 @@ func (s *ImportSet) Pos() src.Pos     { return s.Position }
 func (s *TypeDecl) Pos() src.Pos      { return s.Position }
 func (s *MethodikDecl) Pos() src.Pos  { return s.Position }
 func (s *Const) Pos() src.Pos         { return s.Position }
+func (s *ConstSet) Pos() src.Pos      { return s.Position }
 func (s *Var) Pos() src.Pos           { return s.Position }
 func (s *VarSet) Pos() src.Pos        { return s.Position }
 func (s *Assign) Pos() src.Pos        { return s.Position }

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -98,7 +98,10 @@ func (w *walker) walk(parent, node Node, fieldName string, iter *iterator) {
 		w.walkSlice(node, "Methods")
 
 	case *stmt.Const:
-		w.walk(node, node.Value, "Value", nil)
+		w.walkSlice(node, "Values")
+
+	case *stmt.ConstSet:
+		w.walkSlice(node, "Consts")
 
 	case *stmt.Assign:
 		w.walkSlice(node, "Left")


### PR DESCRIPTION
This CL changes the representation of the const statement to be able to
parse the following snippets:

```go
 const x int = 4
 const x, y = 3, 4
 const x, y int = 3, 4
```

and ditto for const-blocks.

Updates neugram/ng#112.