### PR TITLE
parser,syntax,syntax/stmt: parse var and var-block

### DIFF
--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -667,13 +667,18 @@ func EqualStmt(x, y stmt.Stmt) bool {
 		if !ok {
 			return false
 		}
-		if x.Name != y.Name {
+		if len(x.NameList) != len(y.NameList) {
 			return false
+		}
+		for i := range x.NameList {
+			if x.NameList[i] != y.NameList[i] {
+				return false
+			}
 		}
 		if !tipe.EqualUnresolved(x.Type, y.Type) {
 			return false
 		}
-		if !EqualExpr(x.Value, y.Value) {
+		if !equalExprs(x.Values, y.Values) {
 			return false
 		}
 	case *stmt.VarSet:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1288,17 +1288,30 @@ var stmtTests = []stmtTest{
 	{"{ return }", &stmt.Block{Stmts: []stmt.Stmt{&stmt.Return{}}}},
 	{"{ return 1 }", &stmt.Block{Stmts: []stmt.Stmt{&stmt.Return{Exprs: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(1)}}}}}},
 	{"var i = 10", &stmt.Var{
-		Name:  "i",
-		Value: &expr.BasicLiteral{Value: big.NewInt(10)},
+		NameList: []string{"i"},
+		Values:   []expr.Expr{basic(10)},
 	}},
 	{"var i int", &stmt.Var{
-		Name: "i",
-		Type: &tipe.Unresolved{Name: "int"},
+		NameList: []string{"i"},
+		Type:     &tipe.Unresolved{Name: "int"},
 	}},
 	{"var i int = 11", &stmt.Var{
-		Name:  "i",
-		Value: &expr.BasicLiteral{Value: big.NewInt(11)},
-		Type:  &tipe.Unresolved{Name: "int"},
+		NameList: []string{"i"},
+		Values:   []expr.Expr{basic(11)},
+		Type:     &tipe.Unresolved{Name: "int"},
+	}},
+	{"var i, j = 1, 2", &stmt.Var{
+		NameList: []string{"i", "j"},
+		Values:   []expr.Expr{basic(1), basic(2)},
+	}},
+	{"var i, j int64 = 1, 2", &stmt.Var{
+		NameList: []string{"i", "j"},
+		Type:     tint64,
+		Values:   []expr.Expr{basic(1), basic(2)},
+	}},
+	{"var i, j int64", &stmt.Var{
+		NameList: []string{"i", "j"},
+		Type:     tint64,
 	}},
 	{
 		`var (
@@ -1309,17 +1322,17 @@ var stmtTests = []stmtTest{
 		`, &stmt.VarSet{
 			Vars: []*stmt.Var{
 				{
-					Name:  "i",
-					Value: &expr.BasicLiteral{Value: big.NewInt(11)},
-					Type:  &tipe.Unresolved{Name: "int"},
+					NameList: []string{"i"},
+					Values:   []expr.Expr{basic(11)},
+					Type:     &tipe.Unresolved{Name: "int"},
 				},
 				{
-					Name:  "j",
-					Value: &expr.BasicLiteral{Value: big.NewInt(22)},
+					NameList: []string{"j"},
+					Values:   []expr.Expr{basic(22)},
 				},
 				{
-					Name: "k",
-					Type: &tipe.Unresolved{Name: "float64"},
+					NameList: []string{"k"},
+					Type:     tfloat64,
 				},
 			},
 		},

--- a/syntax/stmt/stmt.go
+++ b/syntax/stmt/stmt.go
@@ -62,9 +62,9 @@ type VarSet struct {
 
 type Var struct {
 	Position src.Pos
-	Name     string
+	NameList []string
 	Type     tipe.Type
-	Value    expr.Expr
+	Values   []expr.Expr
 }
 
 type Assign struct {

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -103,6 +103,12 @@ func (w *walker) walk(parent, node Node, fieldName string, iter *iterator) {
 	case *stmt.ConstSet:
 		w.walkSlice(node, "Consts")
 
+	case *stmt.Var:
+		w.walkSlice(node, "Values")
+
+	case *stmt.VarSet:
+		w.walkSlice(node, "Vars")
+
 	case *stmt.Assign:
 		w.walkSlice(node, "Left")
 		w.walkSlice(node, "Right")


### PR DESCRIPTION
This CL implements parsing vars and var-blocks such as:

```go
 var i = 1
 var i int = 1
 var i int
 var i, j = 1, 2
 var i, j int = 1, 2
 var i, j int
```

and ditto for var-blocks.

Fixes neugram/ng#106.