### PR TITLE
eval,parser: implement var decl of array,map,chan and struct

### DIFF
--- a/eval/testdata/var1.ng
+++ b/eval/testdata/var1.ng
@@ -53,4 +53,40 @@ if u6 != float64(8.8) {
 	panic("ERROR 13")
 }
 
+var m map[string]int
+if len(m) != 0 {
+	panic("ERROR 14")
+}
+
+var ch chan int
+if ch != nil {
+	panic("ERROR 15")
+}
+
+var slice []int
+if len(slice) != 0 {
+	panic("ERROR 16")
+}
+
+var str string
+if str != "" {
+	panic("ERROR 17")
+}
+
+var st struct{N int}
+if st.N != 0 {
+	panic("ERROR 18")
+}
+
+var arr1 [2]int
+if len(arr1) != 2 {
+	panic("ERROR 19")
+}
+
+// TODO
+// var arr2 = [...]int{1, 2}
+// if len(arr2) != 2 {
+// 	panic("ERROR 20")
+// }
+
 print("OK")

--- a/eval/testdata/var2.ng
+++ b/eval/testdata/var2.ng
@@ -8,6 +8,16 @@ var (
 	u1, u2 float64
 	u3, u4 float64 = 3, 4
 	u5, u6 float64 = 7.7, 8.8
+
+	m     map[string]int
+	ch    chan int
+	slice []int
+	str   string
+	st    struct{N int}
+	arr1  [2]int
+
+	// TODO
+	// arr2 = [...]int{1, 2}
 )
 
 if v1 != int(1) {
@@ -56,5 +66,34 @@ if u5 != float64(7.7) {
 if u6 != float64(8.8) {
 	panic("ERROR 13")
 }
+
+if len(m) != 0 {
+	panic("ERROR 14")
+}
+
+if ch != nil {
+	panic("ERROR 15")
+}
+
+if len(slice) != 0 {
+	panic("ERROR 16")
+}
+
+if str != "" {
+	panic("ERROR 17")
+}
+
+if st.N != 0 {
+	panic("ERROR 18")
+}
+
+if len(arr1) != 2 {
+	panic("ERROR 19")
+}
+
+// TODO
+// if len(arr2) != 2 {
+// 	panic("ERROR 20")
+// }
 
 print("OK")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1291,7 +1291,7 @@ items:
 		s.NameList = append(s.NameList, p.s.Literal.(string))
 		p.next()
 		switch p.s.Token {
-		case token.Ident:
+		case token.Chan, token.Ident, token.LeftBracket, token.Map, token.Struct:
 			s.Type = p.parseType()
 			if p.s.Token == token.Assign {
 				p.next()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1319,6 +1319,36 @@ var stmtTests = []stmtTest{
 		NameList: []string{"i", "j"},
 		Type:     tint64,
 	}},
+	{"var i map[string]int", &stmt.Var{
+		NameList: []string{"i"},
+		Type: &tipe.Map{
+			Key:   &tipe.Unresolved{Name: "string"},
+			Value: &tipe.Unresolved{Name: "int"},
+		},
+	}},
+	{"var i chan int", &stmt.Var{
+		NameList: []string{"i"},
+		Type:     &tipe.Chan{Elem: &tipe.Unresolved{Name: "int"}},
+	}},
+	{"var i []int", &stmt.Var{
+		NameList: []string{"i"},
+		Type:     &tipe.Slice{Elem: &tipe.Unresolved{Name: "int"}},
+	}},
+	{"var i [2]int", &stmt.Var{
+		NameList: []string{"i"},
+		Type: &tipe.Array{
+			Len:  2,
+			Elem: &tipe.Unresolved{Name: "int"},
+		},
+	}},
+	{"var i string", &stmt.Var{
+		NameList: []string{"i"},
+		Type:     &tipe.Unresolved{Name: "string"},
+	}},
+	{"var i struct{}", &stmt.Var{
+		NameList: []string{"i"},
+		Type:     &tipe.Struct{},
+	}},
 	{
 		`var (
 			i int = 11


### PR DESCRIPTION
This CL makes sure we can declare values of different builtin types
using the var keyword:
```
var (
	m     map[string]int
	ch    chan int
	slice []int
	str   string
	st    struct{N int}
	arr1  [2]int

	// TODO
	// arr2 = [...]int{1, 2}
)
```
Updates neugram/ng#152.

(Needs neugram/ng#151)