### PR TITLE
all: implement array literals

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1604,6 +1604,14 @@ func (p *Program) evalExpr(e expr.Expr) []reflect.Value {
 		errt := reflect.TypeOf((*error)(nil)).Elem()
 		nilerr := reflect.New(errt).Elem()
 		return []reflect.Value{str, nilerr}
+	case *expr.ArrayLiteral:
+		t := p.reflector.ToRType(e.Type)
+		array := reflect.New(t).Elem()
+		for i, elem := range e.Elems {
+			v := p.evalExprOne(elem)
+			array.Index(i).Set(v)
+		}
+		return []reflect.Value{array}
 	case *expr.SliceLiteral:
 		t := p.reflector.ToRType(e.Type)
 		slice := reflect.MakeSlice(t, len(e.Elems), len(e.Elems))

--- a/eval/testdata/var1.ng
+++ b/eval/testdata/var1.ng
@@ -83,10 +83,9 @@ if len(arr1) != 2 {
 	panic("ERROR 19")
 }
 
-// TODO
-// var arr2 = [...]int{1, 2}
-// if len(arr2) != 2 {
-// 	panic("ERROR 20")
-// }
+var arr2 = [...]int{1, 2}
+if len(arr2) != 2 {
+	panic("ERROR 20")
+}
 
 print("OK")

--- a/eval/testdata/var2.ng
+++ b/eval/testdata/var2.ng
@@ -16,8 +16,7 @@ var (
 	st    struct{N int}
 	arr1  [2]int
 
-	// TODO
-	// arr2 = [...]int{1, 2}
+	arr2 = [...]int{1, 2}
 )
 
 if v1 != int(1) {
@@ -91,9 +90,8 @@ if len(arr1) != 2 {
 	panic("ERROR 19")
 }
 
-// TODO
-// if len(arr2) != 2 {
-// 	panic("ERROR 20")
-// }
+if len(arr2) != 2 {
+	panic("ERROR 20")
+}
 
 print("OK")

--- a/gengo/gengo.go
+++ b/gengo/gengo.go
@@ -505,6 +505,16 @@ func (p *printer) expr(e expr.Expr) {
 			p.newline()
 		}
 		p.printf("})")
+	case *expr.ArrayLiteral:
+		p.tipe(e.Type)
+		p.print("{")
+		for i, elem := range e.Elems {
+			if i > 0 {
+				p.print(", ")
+			}
+			p.expr(elem)
+		}
+		p.print("}")
 	case *expr.SliceLiteral:
 		p.tipe(e.Type)
 		p.print("{")

--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -102,6 +102,21 @@ func EqualExpr(x, y expr.Expr) bool {
 			return false
 		}
 		return true
+	case *expr.ArrayLiteral:
+		y, ok := y.(*expr.ArrayLiteral)
+		if !ok {
+			return false
+		}
+		if x == nil || y == nil {
+			return x == nil && y == nil
+		}
+		if !tipe.EqualUnresolved(x.Type, y.Type) {
+			return false
+		}
+		if !equalExprs(x.Elems, y.Elems) {
+			return false
+		}
+		return true
 	case *expr.SliceLiteral:
 		y, ok := y.(*expr.SliceLiteral)
 		if !ok {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1341,6 +1341,27 @@ var stmtTests = []stmtTest{
 			Elem: &tipe.Unresolved{Name: "int"},
 		},
 	}},
+	{"var i = [2]int{1,2}", &stmt.Var{
+		NameList: []string{"i"},
+		Values: []expr.Expr{&expr.ArrayLiteral{
+			Type: &tipe.Array{
+				Len:  2,
+				Elem: &tipe.Unresolved{Name: "int"},
+			},
+			Elems: []expr.Expr{basic(1), basic(2)},
+		}},
+	}},
+	{"var i = [...]int{1,2}", &stmt.Var{
+		NameList: []string{"i"},
+		Values: []expr.Expr{&expr.ArrayLiteral{
+			Type: &tipe.Array{
+				Len:      2,
+				Elem:     &tipe.Unresolved{Name: "int"},
+				Ellipsis: true,
+			},
+			Elems: []expr.Expr{basic(1), basic(2)},
+		}},
+	}},
 	{"var i string", &stmt.Var{
 		NameList: []string{"i"},
 		Type:     &tipe.Unresolved{Name: "string"},

--- a/syntax/expr/expr.go
+++ b/syntax/expr/expr.go
@@ -89,6 +89,12 @@ type MapLiteral struct {
 	Values   []Expr
 }
 
+type ArrayLiteral struct {
+	Position src.Pos
+	Type     *tipe.Array
+	Elems    []Expr
+}
+
 type SliceLiteral struct {
 	Position src.Pos
 	Type     *tipe.Slice
@@ -200,6 +206,7 @@ func (e *BasicLiteral) expr()   {}
 func (e *FuncLiteral) expr()    {}
 func (e *CompLiteral) expr()    {}
 func (e *MapLiteral) expr()     {}
+func (e *ArrayLiteral) expr()   {}
 func (e *SliceLiteral) expr()   {}
 func (e *TableLiteral) expr()   {}
 func (e *Type) expr()           {}
@@ -225,6 +232,7 @@ func (e *BasicLiteral) Pos() src.Pos   { return e.Position }
 func (e *FuncLiteral) Pos() src.Pos    { return e.Position }
 func (e *CompLiteral) Pos() src.Pos    { return e.Position }
 func (e *MapLiteral) Pos() src.Pos     { return e.Position }
+func (e *ArrayLiteral) Pos() src.Pos   { return e.Position }
 func (e *SliceLiteral) Pos() src.Pos   { return e.Position }
 func (e *TableLiteral) Pos() src.Pos   { return e.Position }
 func (e *Type) Pos() src.Pos           { return e.Position }

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -224,6 +224,9 @@ func (w *walker) walk(parent, node Node, fieldName string, iter *iterator) {
 		w.walkSlice(node, "Keys")
 		w.walkSlice(node, "Values")
 
+	case *expr.ArrayLiteral:
+		w.walkSlice(node, "Elems")
+
 	case *expr.SliceLiteral:
 		w.walkSlice(node, "Elems")
 


### PR DESCRIPTION
This CL implements all aspects of array literals:

```go
 var arr = [...]int{1,2}
 var arr = [2]int{1,2}
```

Fixes neugram/ng#152.

(Needs neugram/ng#155)