### PR TITLE
Map slice chan nil compare

### DIFF
--- a/eval/testdata/array2.ng
+++ b/eval/testdata/array2.ng
@@ -1,0 +1,48 @@
+arr1 := [...]int{1, 2}
+if arr1[0] != 1 {
+	panic("ERROR 1")
+}
+if arr1[1] != 2 {
+	panic("ERROR 2")
+}
+if len(arr1) != 2 {
+	panic("ERROR 3")
+}
+
+arr2 := [2]int{1, 2}
+if arr2[0] != 1 {
+	panic("ERROR 4")
+}
+if arr2[1] != 2 {
+	panic("ERROR 5")
+}
+
+type Array [2]int
+arr3 := Array{1, 2}
+if arr3[0] != 1 {
+	panic("ERROR 6")
+}
+if arr3[1] != 2 {
+	panic("ERROR 7")
+}
+
+arr4 := [...]int{1: 2}
+if arr4[0] != 0 {
+	panic("ERROR 8")
+}
+if arr4[1] != 2 {
+	panic("ERROR 9")
+}
+if len(arr4) != 2 {
+	panic("ERROR 10")
+}
+
+arr5 := Array{1: 2}
+if arr5[0] != 0 {
+	panic("ERROR 11")
+}
+if arr5[1] != 2 {
+	panic("ERROR 12")
+}
+
+print("OK")

--- a/eval/testdata/chan3.ng
+++ b/eval/testdata/chan3.ng
@@ -1,0 +1,27 @@
+ok := 0
+
+var ch1 chan int
+if ch1 != nil {
+	panic("ERROR 1")
+}
+if ch1 == nil {
+	ok++
+}
+
+var ch2 chan int
+if ch2 != nil {
+	panic("ERROR 2")
+}
+if ch2 == nil {
+	ok++
+}
+
+if ch1 == ch2 {
+	ok++
+}
+
+if ok != 3 {
+	panic("ERROR 3")
+}
+
+print("OK")

--- a/eval/testdata/map3_error.ng
+++ b/eval/testdata/map3_error.ng
@@ -1,0 +1,13 @@
+var m1 map[int]int
+if m1 != nil {
+	panic("ERROR 1")
+}
+
+var m2 map[int]int
+if m2 != nil {
+	panic("ERROR 2")
+}
+
+m1 == m2 // ERROR: type map[int]int only comparable to nil
+
+print("OK")

--- a/eval/testdata/slice2.ng
+++ b/eval/testdata/slice2.ng
@@ -1,0 +1,46 @@
+sli1 := []int{1, 2}
+if sli1[0] != 1 {
+	panic("ERROR 1")
+}
+if sli1[1] != 2 {
+	panic("ERROR 2")
+}
+if len(sli1) != 2 {
+	panic("ERROR 3")
+}
+
+type Slice []int
+sli2 := Slice{1, 2}
+if sli2[0] != 1 {
+	panic("ERROR 4")
+}
+if sli2[1] != 2 {
+	panic("ERROR 5")
+}
+if len(sli2) != 2 {
+	panic("ERROR 6")
+}
+
+sli3 := []int{1: 2}
+if sli3[0] != 0 {
+	panic("ERROR 7")
+}
+if sli3[1] != 2 {
+	panic("ERROR 8")
+}
+if len(sli3) != 2 {
+	panic("ERROR 9")
+}
+
+sli4 := Slice{1: 2}
+if sli4[0] != 0 {
+	panic("ERROR 10")
+}
+if sli4[1] != 2 {
+	panic("ERROR 11")
+}
+if len(sli4) != 2 {
+	panic("ERROR 12")
+}
+
+print("OK")

--- a/eval/testdata/slice3_error.ng
+++ b/eval/testdata/slice3_error.ng
@@ -1,0 +1,13 @@
+var s1 []int
+if s1 != nil {
+	panic("ERROR 1")
+}
+
+var s2 []int
+if s2 != nil {
+	panic("ERROR 2")
+}
+
+s1 == s2 // ERROR: type []int only comparable to nil
+
+print("OK")

--- a/format/expr.go
+++ b/format/expr.go
@@ -105,15 +105,90 @@ func (p *printer) expr(e expr.Expr) {
 			p.stmt(e.Body.(*stmt.Block))
 		}
 		/* TODO
-		case *expr.CompLiteral:
-			panic("not implemented")
-		case *expr.MapLiteral:
-			panic("not implemented")
-		case *expr.SliceLiteral:
-			panic("not implemented")
 		case *expr.TableLiteral:
 			panic("not implemented")
 		*/
+	case *expr.CompLiteral:
+		p.tipe(e.Type)
+		p.print("{")
+		if len(e.Keys) > 0 {
+			p.indent++
+			for i, key := range e.Keys {
+				p.newline()
+				p.expr(key)
+				p.print(": ")
+				p.expr(e.Values[i])
+				p.print(",")
+			}
+			p.indent--
+			p.newline()
+		} else if len(e.Values) > 0 {
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(elem)
+			}
+		}
+		p.print("}")
+	case *expr.MapLiteral:
+		p.tipe(e.Type)
+		p.print("{")
+		p.indent++
+		for i, key := range e.Keys {
+			p.newline()
+			p.expr(key)
+			p.print(": ")
+			p.expr(e.Values[i])
+			p.print(",")
+		}
+		p.indent--
+		p.newline()
+		p.print("}")
+	case *expr.ArrayLiteral:
+		p.tipe(e.Type)
+		p.print("{")
+		switch len(e.Keys) {
+		case 0:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(elem)
+			}
+		default:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(e.Keys[i])
+				p.print(": ")
+				p.expr(elem)
+			}
+		}
+		p.print("}")
+	case *expr.SliceLiteral:
+		p.tipe(e.Type)
+		p.print("{")
+		switch len(e.Keys) {
+		case 0:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(elem)
+			}
+		default:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(e.Keys[i])
+				p.print(": ")
+				p.expr(elem)
+			}
+		}
+		p.print("}")
 	case *expr.Type:
 		p.tipe(e.Type)
 	case *expr.Ident:
@@ -251,6 +326,10 @@ func (p *printer) expr(e expr.Expr) {
 
 func (p *printer) printf(format string, args ...interface{}) {
 	fmt.Fprintf(p.buf, format, args...)
+}
+
+func (p *printer) print(args ...interface{}) {
+	fmt.Fprint(p.buf, args...)
 }
 
 func (p *printer) newline() {

--- a/gengo/gengo.go
+++ b/gengo/gengo.go
@@ -485,13 +485,13 @@ func (p *printer) expr(e expr.Expr) {
 				p.newline()
 				p.expr(key)
 				p.print(": ")
-				p.expr(e.Elements[i])
+				p.expr(e.Values[i])
 				p.print(",")
 			}
 			p.indent--
 			p.newline()
-		} else if len(e.Elements) > 0 {
-			for i, elem := range e.Elements {
+		} else if len(e.Values) > 0 {
+			for i, elem := range e.Values {
 				if i > 0 {
 					p.print(", ")
 				}
@@ -557,21 +557,45 @@ func (p *printer) expr(e expr.Expr) {
 	case *expr.ArrayLiteral:
 		p.tipe(e.Type)
 		p.print("{")
-		for i, elem := range e.Elems {
-			if i > 0 {
-				p.print(", ")
+		switch len(e.Keys) {
+		case 0:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(elem)
 			}
-			p.expr(elem)
+		default:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(e.Keys[i])
+				p.print(": ")
+				p.expr(elem)
+			}
 		}
 		p.print("}")
 	case *expr.SliceLiteral:
 		p.tipe(e.Type)
 		p.print("{")
-		for i, elem := range e.Elems {
-			if i > 0 {
-				p.print(", ")
+		switch len(e.Keys) {
+		case 0:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(elem)
 			}
-			p.expr(elem)
+		default:
+			for i, elem := range e.Values {
+				if i > 0 {
+					p.print(", ")
+				}
+				p.expr(e.Keys[i])
+				p.print(": ")
+				p.expr(elem)
+			}
 		}
 		p.print("}")
 	case *expr.Type:

--- a/gengo/gengo_test.go
+++ b/gengo/gengo_test.go
@@ -41,6 +41,7 @@ func TestGeneratedPrograms(t *testing.T) {
 			"import8",
 			"op1",
 			"slice1",
+			"array2",
 		}
 		donotrun := false
 		for _, ex := range exclude {

--- a/parser/expr_equal.go
+++ b/parser/expr_equal.go
@@ -80,7 +80,7 @@ func EqualExpr(x, y expr.Expr) bool {
 		if !equalExprs(x.Keys, y.Keys) {
 			return false
 		}
-		if !equalExprs(x.Elements, y.Elements) {
+		if !equalExprs(x.Values, y.Values) {
 			return false
 		}
 		return true
@@ -113,7 +113,10 @@ func EqualExpr(x, y expr.Expr) bool {
 		if !tipe.EqualUnresolved(x.Type, y.Type) {
 			return false
 		}
-		if !equalExprs(x.Elems, y.Elems) {
+		if !equalExprs(x.Keys, y.Keys) {
+			return false
+		}
+		if !equalExprs(x.Values, y.Values) {
 			return false
 		}
 		return true
@@ -128,7 +131,10 @@ func EqualExpr(x, y expr.Expr) bool {
 		if !tipe.EqualUnresolved(x.Type, y.Type) {
 			return false
 		}
-		if !equalExprs(x.Elems, y.Elems) {
+		if !equalExprs(x.Keys, y.Keys) {
+			return false
+		}
+		if !equalExprs(x.Values, y.Values) {
 			return false
 		}
 		return true

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -860,9 +860,9 @@ var stmtTests = []stmtTest{
 		},
 	},
 	{"S{ X: 7 }", &stmt.Simple{Expr: &expr.CompLiteral{
-		Type:     &tipe.Unresolved{Name: "S"},
-		Keys:     []expr.Expr{&expr.Ident{Name: "X"}},
-		Elements: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(7)}},
+		Type:   &tipe.Unresolved{Name: "S"},
+		Keys:   []expr.Expr{&expr.Ident{Name: "X"}},
+		Values: []expr.Expr{&expr.BasicLiteral{Value: big.NewInt(7)}},
 	}}},
 	{`map[string]string{ "foo": "bar" }`, &stmt.Simple{Expr: &expr.MapLiteral{
 		Type:   &tipe.Map{Key: &tipe.Unresolved{Name: "string"}, Value: &tipe.Unresolved{Name: "string"}},
@@ -1348,7 +1348,18 @@ var stmtTests = []stmtTest{
 				Len:  2,
 				Elem: &tipe.Unresolved{Name: "int"},
 			},
-			Elems: []expr.Expr{basic(1), basic(2)},
+			Values: []expr.Expr{basic(1), basic(2)},
+		}},
+	}},
+	{"var i = [2]int{1:2}", &stmt.Var{
+		NameList: []string{"i"},
+		Values: []expr.Expr{&expr.ArrayLiteral{
+			Type: &tipe.Array{
+				Len:  2,
+				Elem: &tipe.Unresolved{Name: "int"},
+			},
+			Keys:   []expr.Expr{basic(1)},
+			Values: []expr.Expr{basic(2)},
 		}},
 	}},
 	{"var i = [...]int{1,2}", &stmt.Var{
@@ -1359,7 +1370,29 @@ var stmtTests = []stmtTest{
 				Elem:     &tipe.Unresolved{Name: "int"},
 				Ellipsis: true,
 			},
-			Elems: []expr.Expr{basic(1), basic(2)},
+			Values: []expr.Expr{basic(1), basic(2)},
+		}},
+	}},
+	{"var i = [...]int{1:2}", &stmt.Var{
+		NameList: []string{"i"},
+		Values: []expr.Expr{&expr.ArrayLiteral{
+			Type: &tipe.Array{
+				Len:      2,
+				Elem:     &tipe.Unresolved{Name: "int"},
+				Ellipsis: true,
+			},
+			Keys:   []expr.Expr{basic(1)},
+			Values: []expr.Expr{basic(2)},
+		}},
+	}},
+	{"var i = []int{1:2}", &stmt.Var{
+		NameList: []string{"i"},
+		Values: []expr.Expr{&expr.SliceLiteral{
+			Type: &tipe.Slice{
+				Elem: &tipe.Unresolved{Name: "int"},
+			},
+			Keys:   []expr.Expr{basic(1)},
+			Values: []expr.Expr{basic(2)},
 		}},
 	}},
 	{"var i string", &stmt.Var{

--- a/syntax/expr/expr.go
+++ b/syntax/expr/expr.go
@@ -79,7 +79,7 @@ type CompLiteral struct {
 	Position src.Pos
 	Type     tipe.Type
 	Keys     []Expr // TODO: could make this []string
-	Elements []Expr
+	Values   []Expr
 }
 
 type MapLiteral struct {
@@ -92,13 +92,15 @@ type MapLiteral struct {
 type ArrayLiteral struct {
 	Position src.Pos
 	Type     *tipe.Array
-	Elems    []Expr
+	Keys     []Expr // TODO: could make this []int
+	Values   []Expr
 }
 
 type SliceLiteral struct {
 	Position src.Pos
 	Type     *tipe.Slice
-	Elems    []Expr
+	Keys     []Expr // TODO: could make this []int
+	Values   []Expr
 }
 
 type TableLiteral struct {

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -218,17 +218,19 @@ func (w *walker) walk(parent, node Node, fieldName string, iter *iterator) {
 
 	case *expr.CompLiteral:
 		w.walkSlice(node, "Keys")
-		w.walkSlice(node, "Elements")
+		w.walkSlice(node, "Values")
 
 	case *expr.MapLiteral:
 		w.walkSlice(node, "Keys")
 		w.walkSlice(node, "Values")
 
 	case *expr.ArrayLiteral:
-		w.walkSlice(node, "Elems")
+		w.walkSlice(node, "Keys")
+		w.walkSlice(node, "Values")
 
 	case *expr.SliceLiteral:
-		w.walkSlice(node, "Elems")
+		w.walkSlice(node, "Keys")
+		w.walkSlice(node, "Values")
 
 	case *expr.TableLiteral:
 		w.walkSlice(node, "ColNames")

--- a/typecheck/typecheck.go
+++ b/typecheck/typecheck.go
@@ -2062,7 +2062,6 @@ func (c *Checker) exprPartial(e expr.Expr, hint typeHint) (p partial) {
 		return p
 	case *expr.CompLiteral:
 		p.mode = modeVar
-		structName := fmt.Sprintf("%s", e.Type)
 		if t, resolved := c.resolve(e.Type); resolved {
 			e.Type = t
 			p.typ = t
@@ -2070,65 +2069,22 @@ func (c *Checker) exprPartial(e expr.Expr, hint typeHint) (p partial) {
 			p.mode = modeInvalid
 			return p
 		}
-		t, isStruct := tipe.Underlying(e.Type).(*tipe.Struct)
-		if !isStruct {
+		switch t := tipe.Underlying(e.Type).(type) {
+		case *tipe.Struct:
+			return c.checkStructLiteral(e, t, p)
+		case *tipe.Array:
+			p = c.checkArrayLiteral(e, e.Keys, e.Values, t, p)
+		case *tipe.Slice:
+			p = c.checkSliceLiteral(e, e.Keys, e.Values, t, p)
+		case *tipe.Map:
+			p = c.checkMapLiteral(e, e.Keys, e.Values, t, p)
+		default:
 			c.errorfmt("cannot construct type %s with a composite literal", e.Type)
 			p.mode = modeInvalid
 			return p
 		}
-		elemsp := make([]partial, len(e.Elements))
-		for i, elem := range e.Elements {
-			elemsp[i] = c.expr(elem)
-			if elemsp[i].mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-		}
-		if len(e.Keys) == 0 {
-			if len(e.Elements) == 0 {
-				return p
-			}
-			if len(e.Elements) != len(t.Fields) {
-				c.errorfmt("wrong number of elements, %d, when %s expects %d", len(e.Elements), structName, len(t.Fields))
-				p.mode = modeInvalid
-				return p
-			}
-			for i, sf := range t.Fields {
-				c.assign(&elemsp[i], sf.Type)
-				if elemsp[i].mode == modeInvalid {
-					p.mode = modeInvalid
-					return p
-				}
-			}
-		} else {
-			namedp := make(map[string]partial)
-			for i, elemp := range elemsp {
-				ident, ok := e.Keys[i].(*expr.Ident)
-				if !ok {
-					c.errorfmt("invalid field name %s in struct initializer", e.Keys[i])
-					p.mode = modeInvalid
-					return p
-				}
-				namedp[ident.Name] = elemp
-			}
-			for _, sf := range t.Fields {
-				elemp, found := namedp[sf.Name]
-				if !found {
-					continue
-				}
-				c.assign(&elemp, sf.Type)
-				if elemp.mode == modeInvalid {
-					p.mode = modeInvalid
-					return p
-				}
-			}
-			//panic("TODO: named CompLiteral")
-		}
-		if p.mode != modeInvalid {
-			p.expr = e
-		}
+		p.expr = e
 		return p
-
 	case *expr.MapLiteral:
 		p.mode = modeVar
 		if t, resolved := c.resolve(e.Type); resolved {
@@ -2144,32 +2100,7 @@ func (c *Checker) exprPartial(e expr.Expr, hint typeHint) (p partial) {
 			p.mode = modeInvalid
 			return p
 		}
-		for _, k := range e.Keys {
-			kp := c.expr(k)
-			if kp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-			c.assign(&kp, t.Key)
-			if kp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-		}
-		for _, v := range e.Values {
-			vp := c.expr(v)
-			if vp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-			c.assign(&vp, t.Value)
-			if vp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-		}
-		p.expr = e
-		return p
+		return c.checkMapLiteral(e, e.Keys, e.Values, t, p)
 
 	case *expr.ArrayLiteral:
 		p.mode = modeVar
@@ -2188,21 +2119,7 @@ func (c *Checker) exprPartial(e expr.Expr, hint typeHint) (p partial) {
 			p.mode = modeInvalid
 			return p
 		}
-
-		for _, v := range e.Elems {
-			vp := c.expr(v)
-			if vp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-			c.assign(&vp, arrayType.Elem)
-			if vp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-		}
-		p.expr = e
-		return p
+		return c.checkArrayLiteral(e, e.Keys, e.Values, arrayType, p)
 
 	case *expr.SliceLiteral:
 		p.mode = modeVar
@@ -2221,21 +2138,7 @@ func (c *Checker) exprPartial(e expr.Expr, hint typeHint) (p partial) {
 			p.mode = modeInvalid
 			return p
 		}
-
-		for _, v := range e.Elems {
-			vp := c.expr(v)
-			if vp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-			c.assign(&vp, sliceType.Elem)
-			if vp.mode == modeInvalid {
-				p.mode = modeInvalid
-				return p
-			}
-		}
-		p.expr = e
-		return p
+		return c.checkSliceLiteral(e, e.Keys, e.Values, sliceType, p)
 
 	case *expr.TableLiteral:
 		p.mode = modeVar
@@ -2656,6 +2559,150 @@ func (c *Checker) exprPartial(e expr.Expr, hint typeHint) (p partial) {
 		return p
 	}
 	panic(fmt.Sprintf("expr TODO: %s", format.Debug(e)))
+}
+
+func (c *Checker) checkStructLiteral(e *expr.CompLiteral, t *tipe.Struct, p partial) partial {
+	structName := fmt.Sprintf("%s", e.Type)
+	elemsp := make([]partial, len(e.Values))
+	for i, elem := range e.Values {
+		elemsp[i] = c.expr(elem)
+		if elemsp[i].mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	if len(e.Keys) == 0 {
+		if len(e.Values) == 0 {
+			return p
+		}
+		if len(e.Values) != len(t.Fields) {
+			c.errorfmt("wrong number of elements, %d, when %s expects %d", len(e.Values), structName, len(t.Fields))
+			p.mode = modeInvalid
+			return p
+		}
+		for i, sf := range t.Fields {
+			c.assign(&elemsp[i], sf.Type)
+			if elemsp[i].mode == modeInvalid {
+				p.mode = modeInvalid
+				return p
+			}
+		}
+	} else {
+		namedp := make(map[string]partial)
+		for i, elemp := range elemsp {
+			ident, ok := e.Keys[i].(*expr.Ident)
+			if !ok {
+				c.errorfmt("invalid field name %s in struct initializer", e.Keys[i])
+				p.mode = modeInvalid
+				return p
+			}
+			namedp[ident.Name] = elemp
+		}
+		for _, sf := range t.Fields {
+			elemp, found := namedp[sf.Name]
+			if !found {
+				continue
+			}
+			c.assign(&elemp, sf.Type)
+			if elemp.mode == modeInvalid {
+				p.mode = modeInvalid
+				return p
+			}
+		}
+		//panic("TODO: named CompLiteral")
+	}
+	if p.mode != modeInvalid {
+		p.expr = e
+	}
+	return p
+
+}
+
+func (c *Checker) checkMapLiteral(e expr.Expr, keys, vals []expr.Expr, t *tipe.Map, p partial) partial {
+	for _, k := range keys {
+		kp := c.expr(k)
+		if kp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+		c.assign(&kp, t.Key)
+		if kp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	for _, v := range vals {
+		vp := c.expr(v)
+		if vp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+		c.assign(&vp, t.Value)
+		if vp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	p.expr = e
+	return p
+}
+
+func (c *Checker) checkArrayLiteral(e expr.Expr, keys, vals []expr.Expr, t *tipe.Array, p partial) partial {
+	for _, k := range keys {
+		kp := c.expr(k)
+		if kp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+		c.assign(&kp, tipe.Int)
+		if kp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	for _, v := range vals {
+		vp := c.expr(v)
+		if vp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+		c.assign(&vp, t.Elem)
+		if vp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	p.expr = e
+	return p
+}
+
+func (c *Checker) checkSliceLiteral(e expr.Expr, keys, vals []expr.Expr, t *tipe.Slice, p partial) partial {
+	for _, k := range keys {
+		kp := c.expr(k)
+		if kp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+		c.assign(&kp, tipe.Int)
+		if kp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	for _, v := range vals {
+		vp := c.expr(v)
+		if vp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+		c.assign(&vp, t.Elem)
+		if vp.mode == modeInvalid {
+			p.mode = modeInvalid
+			return p
+		}
+	}
+	p.expr = e
+	return p
 }
 
 func (c *Checker) shell(cmd expr.Expr) {


### PR DESCRIPTION
This CL implements the following comparisons:

```go
  var ch chan int
  ch == nil
  ch != nil

  var m map[int]int
  m == nil
  m != nil

  var s []int
  s == nil
  s != nil
```

Fixes neugram/ng#153.
Fixes neugram/ng#154.