### PR TITLE
gengo: test array ellipsis

### DIFF
--- a/gengo/gengo_test.go
+++ b/gengo/gengo_test.go
@@ -41,7 +41,6 @@ func TestGeneratedPrograms(t *testing.T) {
 			"import8",
 			"op1",
 			"slice1",
-			"array2",
 		}
 		donotrun := false
 		for _, ex := range exclude {


### PR DESCRIPTION
support for arrays declared and defined via an ellipsis was
added in 9b36d3d570c08eca8592ee36e1a4b6a6dad8231f.