### PR TITLE
travis: temporarily drop 1.9.x from required OK-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ go:
   - master
 os:
   - linux
+matrix:
+ fast_finish: true
+ allow_failures:
+   - go: 1.9.x
+
 
 script:
   - ./.ci-test


### PR DESCRIPTION
Updates neugram/ng#175.