### PR TITLE
eval,parser: allow padding fields in structs

### DIFF
--- a/eval/testdata/typedecl.ng
+++ b/eval/testdata/typedecl.ng
@@ -22,4 +22,10 @@ type T8 struct {
 	B string "xml"
 }
 
+type Padding struct {
+	_ [4]byte
+	N string
+	_ [4]byte
+}
+
 print("OK")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -770,7 +770,7 @@ func (p *Parser) maybeParseType() tipe.Type {
 				ftag = tipe.StructTag(str)
 				p.next()
 			}
-			if n != "" && tags[n] {
+			if n != "" && n != "_" && tags[n] {
 				p.errorf("field %s redeclared in struct %s", n, format.Type(s))
 			} else {
 				tags[n] = true

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -834,6 +834,29 @@ var stmtTests = []stmtTest{
 			}}},
 		},
 	}},
+	{`type T struct {
+		_ [4]byte
+		N string
+		_ [4]byte
+	}`, &stmt.TypeDecl{
+		Name: "T",
+		Type: &tipe.Named{
+			Type: &tipe.Struct{Fields: []tipe.StructField{
+				{
+					Name: "_",
+					Type: &tipe.Array{Len: 4, Elem: &tipe.Unresolved{Name: "byte"}},
+				},
+				{
+					Name: "N",
+					Type: &tipe.Unresolved{Name: "string"},
+				},
+				{
+					Name: "_",
+					Type: &tipe.Array{Len: 4, Elem: &tipe.Unresolved{Name: "byte"}},
+				},
+			}},
+		},
+	}},
 	{
 		`type (
 			T int64


### PR DESCRIPTION
Fixes neugram/ng#173.