### PR TITLE
parser,syntax/token,typecheck: introduce '{|' and '|}' tokens

### DIFF
--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -521,7 +521,13 @@ func (s *Scanner) Next() {
 		s.semi = true
 		s.Token = token.RightBracket
 	case '{':
-		s.Token = token.LeftBrace
+		switch s.r {
+		case '|':
+			s.next()
+			s.Token = token.LeftBraceTable
+		default:
+			s.Token = token.LeftBrace
+		}
 	case '}':
 		s.semi = true
 		s.Token = token.RightBrace
@@ -670,6 +676,10 @@ func (s *Scanner) Next() {
 		case '|':
 			s.next()
 			s.Token = token.LogicalOr
+		case '}':
+			s.next()
+			s.semi = true
+			s.Token = token.RightBraceTable
 		default:
 			s.Token = token.Pipe
 		}

--- a/syntax/token/token.go
+++ b/syntax/token/token.go
@@ -64,17 +64,19 @@ const (
 	PowAssign // ^=
 	Define    // :=
 
-	LeftParen    // (
-	LeftBracket  // [
-	LeftBrace    // {
-	RightParen   // )
-	RightBracket // ]
-	RightBrace   // }
-	Comma        // ,
-	Period       // .
-	Semicolon    // ;
-	Colon        // :
-	Pipe         // |
+	LeftParen       // (
+	LeftBracket     // [
+	LeftBrace       // {
+	LeftBraceTable  // {|
+	RightParen      // )
+	RightBracket    // ]
+	RightBrace      // }
+	RightBraceTable // |}
+	Comma           // ,
+	Period          // .
+	Semicolon       // ;
+	Colon           // :
+	Pipe            // |
 
 	// Keywords
 
@@ -160,9 +162,10 @@ var tokens = map[string]Token{
 	"(":            LeftParen,
 	"[":            LeftBracket,
 	"{":            LeftBrace,
+	"{|":           LeftBraceTable,
 	")":            RightParen,
 	"]":            RightBracket,
-	"}":            RightBrace,
+	"|}":           RightBraceTable,
 	",":            Comma,
 	".":            Period,
 	";":            Semicolon,


### PR DESCRIPTION
This CL introduces 2 new tokens: '{|' and '|}' to ease parsing and lift
ambiguities with the support for the binary '|' oeprator.