### PR TITLE
parser: swap own shell parser with mvdan.cc/sh

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -170,8 +170,8 @@ func (p *Parser) work() {
 		// makes a simple expression behave like an interactive shell.
 		if p.res.State != StateCmd && p.s.Token == token.Shell {
 			p.res.State = StateCmd
-		} else if p.res.State == StateCmd {
 			p.interactive = true
+			p.s.Token = token.ShellWord
 			cmd := p.parseShellList()
 			p.interactive = false
 			if cmd != nil {
@@ -1819,15 +1819,16 @@ func (p *Parser) parseOperand() expr.Expr {
 			Position: p.pos(),
 			TrapOut:  true,
 		}
-		p.next()
+		p.s.Token = token.ShellWord
 		for p.s.Token > 0 && p.s.Token != token.Shell {
 			restore := p.interactive
 			p.interactive = false
 			cmd := p.parseShellList()
 			p.interactive = restore
-			x.Cmds = append(x.Cmds, cmd)
+			if cmd != nil {
+				x.Cmds = append(x.Cmds, cmd)
+			}
 		}
-		p.expect(token.Shell)
 		p.next()
 		return x
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -283,7 +283,8 @@ var parserTests = []parserTest{
 		Rows:     [][]expr.Expr{{basic(1)}, {basic(2)}},
 	}},
 	*/
-	{"($$ls$$)", &expr.Unary{ // for Issue #50
+	// TODO(mvdan): support non-spaced $$ in "$$ls$$" in sh/syntax?
+	{"($$ ls $$)", &expr.Unary{ // for Issue #50
 		Op: token.LeftParen,
 		Expr: &expr.Shell{
 			Cmds: []*expr.ShellList{{AndOr: []*expr.ShellAndOr{{Pipeline: []*expr.ShellPipeline{{
@@ -618,7 +619,7 @@ func simplesh(args ...string) *expr.Shell {
 
 func TestParseShell(t *testing.T) {
 	for _, test := range shellTests {
-		fmt.Printf("Parsing %q\n", test.input)
+		//fmt.Printf("Parsing %q\n", test.input)
 		s, err := parser.ParseStmt([]byte("($$ " + test.input + " $$)"))
 		if err != nil {
 			t.Errorf("ParseExpr(%q): error: %v", test.input, err)


### PR DESCRIPTION
For now, simply use the parser and translate the AST into what the rest
of neugram expects. This is the smallest change that can be made without
breaking neugram.

Once the interpreter in mvdan.cc/sh/interp also starts being used, we
can then get rid of the code translating ASTs and neugram's own shell
AST code.

We can keep the semantics of ShellList and parseShellList thanks to
sh/syntax.Parser.Stmts, which lets us control how to parse a program
statement by statement.

The only complication comes from handing the underlying bytes from one
lexer to another. The neugram lexer has to be careful to not tokenize
any shell bytes, and vice versa.